### PR TITLE
Use the JSGF gem for parsing JSGF files

### DIFF
--- a/lib/pocketsphinx/configuration/grammar.rb
+++ b/lib/pocketsphinx/configuration/grammar.rb
@@ -1,19 +1,28 @@
+require 'jsgf'
+
 module Pocketsphinx
   module Configuration
     class Grammar < Default
       attr_accessor :grammar
 
+      # @param path [String,JSGF::Grammar]  the JSGF file to load, or a {JSGF::Grammar}
       def initialize(*args, &block)#(grammar_path = nil)
         super()
 
-        @grammar = Pocketsphinx::Grammar::Jsgf.new(*args, &block)
+        raise "Either a path or block is required to create a JSGF grammar" if args.empty? && !block_given?
+
+        if block_given?
+          @grammar = Pocketsphinx::Grammar::Jsgf.new(*args, &block)
+        else
+          @grammar = args.first.is_a?(JSGF::Grammar) ? args.first : JSGF.read(*args) rescue raise('Invalid JSGF grammar')
+        end
       end
 
       # Since JSGF strings are not supported in Pocketsphinx configuration (only files),
       # we use the post_init_decoder hook to configure the JSGF
       def post_init_decoder(decoder)
         decoder.unset_search
-        decoder.set_jsgf_string(grammar.raw)
+        decoder.set_jsgf_string(grammar.to_s)
         decoder.set_search
       end
     end

--- a/lib/pocketsphinx/grammar/jsgf.rb
+++ b/lib/pocketsphinx/grammar/jsgf.rb
@@ -26,6 +26,10 @@ module Pocketsphinx
         builder.jsgf
       end
 
+      def to_s
+        raw
+      end
+
       private
 
       def check_grammar

--- a/pocketsphinx-ruby.gemspec
+++ b/pocketsphinx-ruby.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "ffi", ">= 1.9"
+  spec.add_dependency "jsgf", ">= 0.2.1"
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"

--- a/spec/grammar_spec.rb
+++ b/spec/grammar_spec.rb
@@ -7,10 +7,10 @@ describe Pocketsphinx::Grammar::Jsgf do
 
   context "reading a grammar from a file" do
     let(:grammar_path) { grammar :goforward }
-    subject { Pocketsphinx::Grammar::Jsgf.new(grammar_path) }
+    subject { Pocketsphinx::Configuration::Grammar.new(grammar_path) }
 
     it "reads a grammar from a file" do
-      expect(subject.raw.lines.count).to eq(15)
+      expect(subject.grammar.rules.count).to eq(4)
     end
 
     context "the grammar file is invalid" do


### PR DESCRIPTION
I created a gem for handling JSGF files, and this is a patch for using said gem, in case you're interested. I was working on it anyway, and thought I'd share the results. It's a bit of a hack because I didn't want to change too much, and because I wanted to keep the existing DSL functionality (I haven't yet added a DSL to the gem). 

If there's a better way to do this, just let me know and I'll be happy to change it. I think it would be cleaner to bypass the JSGF parser that's built into sphinx, but that's a bigger task that I haven't fully looked into yet.