### PR TITLE
Added support for creating a Jsgf object from a string

### DIFF
--- a/lib/pocketsphinx/grammar/jsgf.rb
+++ b/lib/pocketsphinx/grammar/jsgf.rb
@@ -3,13 +3,24 @@ module Pocketsphinx
     class Jsgf
       attr_reader :raw
 
-      def initialize(path = nil, &block)
-        if path.nil? && !block_given?
+      # A convenience method for creating a new {Jsgf} from a string
+      # @param jsgf_string  [String]  the JSGF string to use
+      def self.from_string(jsgf_string)
+        self.new(nil, jsgf_string)
+      end
+
+      # @param path [String]  the path to the file to be loaded
+      # @param jsgf [String]  a string to be parsed as a JSGF grammar (set path to nil)
+      def initialize(path = nil, jsgf = nil, &block)
+        if path.nil? && jsgf.nil? && !block_given?
           raise "Either a path or block is required to create a JSGF grammar"
         end
 
         if block_given?
           @raw = grammar_from_block(&block)
+        elsif jsgf
+          @raw = jsgf
+          check_grammar
         else
           @raw = grammar_from_file(path)
           check_grammar
@@ -30,7 +41,7 @@ module Pocketsphinx
 
       def check_grammar
         # Simple header check for now
-        raise 'Invalid JSGF grammar' unless raw.lines.first.strip == "#JSGF V1.0;"
+        raise 'Invalid JSGF grammar' unless raw.lines.first && raw.lines.first.strip == "#JSGF V1.0;"
       end
     end
   end

--- a/spec/grammar_spec.rb
+++ b/spec/grammar_spec.rb
@@ -35,6 +35,19 @@ describe Pocketsphinx::Grammar::Jsgf do
     end
   end
 
+  context "building a grammar from a string" do
+    it "stores the string" do
+      grammar = Pocketsphinx::Grammar::Jsgf.from_string("#JSGF V1.0;\ngrammar turtle;\npublic <turtle> = go forward ten meters;")
+      expect(grammar.raw.lines.count).to eq(3)
+    end
+
+    context "the grammar string is invalid" do
+      it "raises an exception" do
+        expect { Pocketsphinx::Grammar::Jsgf.from_string("") }.to raise_exception "Invalid JSGF grammar"
+      end
+    end
+  end
+
   private
 
   def grammar(name)


### PR DESCRIPTION
This allows for the use of JSGF grammars that don't live in files, or are otherwise generated elsewhere.

This implementation abuses optional arguments and therefore may not be the best way to do it, but I wasn't sure what exactly you'd prefer. Jsgf::initialize already takes a string parameter that it expects to be the filename, which makes it tough to simply pass a grammar string. So I added an optional second parameter ('jsgf') and a class-level convenience-method so that nobody needs to know about the new parameter. I'm happy to change the implementation if you prefer something else.