### PR TITLE
Change word frames type from int16 to int32

### DIFF
--- a/lib/pocketsphinx/decoder.rb
+++ b/lib/pocketsphinx/decoder.rb
@@ -115,8 +115,8 @@ module Pocketsphinx
     # @return [Array] Array of words with start/end frame values (10msec/frame)
     def words
       mp_path_score = FFI::MemoryPointer.new(:int32, 1)
-      start_frame   = FFI::MemoryPointer.new(:int16, 1)
-      end_frame     = FFI::MemoryPointer.new(:int16, 1)
+      start_frame   = FFI::MemoryPointer.new(:int32, 1)
+      end_frame     = FFI::MemoryPointer.new(:int32, 1)
 
       seg_iter = ps_api.ps_seg_iter(ps_decoder, mp_path_score)
       words    = []
@@ -125,8 +125,8 @@ module Pocketsphinx
         ps_api.ps_seg_frames(seg_iter, start_frame, end_frame)
         words << Pocketsphinx::Decoder::Word.new(
           ps_api.ps_seg_word(seg_iter),
-          start_frame.get_int16(0),
-          end_frame.get_int16(0)
+          start_frame.get_int32(0),
+          end_frame.get_int32(0)
         )
         seg_iter = ps_api.ps_seg_next(seg_iter)
       end


### PR DESCRIPTION
[PocketSphinx API Documentation](http://www.speech.cs.cmu.edu/sphinx/doc/doxygen/pocketsphinx/main.html) is outdated. Segmentation iterator does not have frames as int16 as stated [here](http://www.speech.cs.cmu.edu/sphinx/doc/doxygen/pocketsphinx/structps__seg__s.html). See latest pocketsphinx repository files:
- [pocketsphinx_internal.h:170](https://github.com/cmusphinx/pocketsphinx/blob/b66fb744433cf90aadcc432c93425a1d5439f221/src/libpocketsphinx/pocketsphinx_internal.h#L170)
- [hmm.h:64](https://github.com/cmusphinx/pocketsphinx/blob/b66fb744433cf90aadcc432c93425a1d5439f221/src/libpocketsphinx/hmm.h#L64)

Sorry I didn't check it while implementing words functionality. 