### PR TITLE
Removed the ability to pass and initial configuration object to Decoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ To open this audio file take a look at [this wiki page](https://github.com/watso
 The `Decoder` class uses Pocketsphinx's libpocketsphinx to decode audio data into text. For example to decode a single utterance:
 
 ```ruby
-decoder = Pocketsphinx::Decoder.new(Pocketsphinx::Configuration.default)
+decoder = Pocketsphinx::Decoder.new
 decoder.decode 'spec/assets/audio/goforward.raw'
 
 puts decoder.hypothesis # => "go forward ten meters"
@@ -150,10 +150,10 @@ decoder.words
 # ]
 ```
 
-Note: When the `Decoder` is initialized, the supplied `Configuration` is updated by Pocketsphinx with some settings from the acoustic model. To see exactly what's going on:
+> Note: When the `Decoder` is initialized, the supplied `Configuration` is updated by the system CMU Pocketsphinx libraries with acoustic model settings that are configured outside of this gem.  To see exactly what's being configured by your local libraries:
 
 ```ruby
-Pocketsphinx::Decoder.new(Pocketsphinx::Configuration.default).configuration.changes
+Pocketsphinx::Decoder.new.configuration.changes
 ```
 
 

--- a/lib/pocketsphinx/decoder.rb
+++ b/lib/pocketsphinx/decoder.rb
@@ -25,8 +25,13 @@ module Pocketsphinx
     #
     # @param [Configuration] configuration
     # @param [FFI::Pointer] ps_decoder An optional Pocketsphinx decoder. One is initialized if not provided.
-    def initialize(configuration, ps_decoder = nil)
-      @configuration = configuration
+    def initialize(ps_decoder = nil)
+      # The underlying cmu-pocketsphinx library has its own configuration workflow and parameter files and
+      # any parameters passed into the decoder initializtion may be selectively overwritten at any time by
+      # the underlying library.  As such, Configuration.default should not be viewed as a reliable
+      # configuration object, and is provided here to fill in any additional parameters that are not already
+      # specified in the underlying system libraries.
+      @configuration = Pocketsphinx::Configuration.default
       init_decoder if ps_decoder.nil?
     end
 


### PR DESCRIPTION
Removed the ability to pass and initial configuration object to Decoder since any configuration object would be overwritten by the underlying Pocketsphinx libraries.

This should help further reduce configuration confusion since the `Decoder.new` really doesn't obey the configuration parameters (discussed further in https://github.com/watsonbox/pocketsphinx-ruby/issues/12)