### PR TITLE
Buffer too large

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,9 @@ microphone = Pocketsphinx::Microphone.new
 
 File.open("test.raw", "wb") do |file|
   microphone.record do
-    FFI::MemoryPointer.new(:int16, 4096) do |buffer|
+    FFI::MemoryPointer.new(:int16, 2048) do |buffer|
       50.times do
-        sample_count = microphone.read_audio(buffer, 4096)
+        sample_count = microphone.read_audio(buffer, 2048)
         file.write buffer.get_bytes(0, sample_count * 2)
 
         sleep 0.1

--- a/examples/record_audio_file.rb
+++ b/examples/record_audio_file.rb
@@ -5,7 +5,7 @@ require "pocketsphinx-ruby"
 
 include Pocketsphinx
 
-MAX_SAMPLES = 4096
+MAX_SAMPLES = 2048
 RECORDING_INTERVAL = 0.1
 RECORDING_LENGTH = 5
 

--- a/lib/pocketsphinx/audio_file.rb
+++ b/lib/pocketsphinx/audio_file.rb
@@ -6,7 +6,7 @@ module Pocketsphinx
     # @param [FFI::Pointer] buffer 16bit buffer of at least max_samples in size
     # @params [Fixnum] max_samples The maximum number of samples to read from the audio file
     # @return [Fixnum] Samples actually read; nil if EOF
-    def read_audio(buffer, max_samples = 4096)
+    def read_audio(buffer, max_samples = 2048)
       if file.nil?
         raise "Can't read audio: use AudioFile#start_recording to open the file first"
       end

--- a/lib/pocketsphinx/audio_file_speech_recognizer.rb
+++ b/lib/pocketsphinx/audio_file_speech_recognizer.rb
@@ -1,7 +1,7 @@
 module Pocketsphinx
   # High-level class for live speech recognition from a raw audio file.
   class AudioFileSpeechRecognizer < SpeechRecognizer
-    def recognize(file_path, max_samples = 4096)
+    def recognize(file_path, max_samples = 2048)
       self.recordable = AudioFile.new(file_path)
 
       super(max_samples) do |speech|

--- a/lib/pocketsphinx/microphone.rb
+++ b/lib/pocketsphinx/microphone.rb
@@ -49,7 +49,7 @@ module Pocketsphinx
     # @params [Fixnum] max_samples The maximum number of samples to read from the audio device
     # @return [Fixnum] Samples actually read (could be 0 since non-blocking); nil if not
     #   recording and no more samples remaining to be read from most recent recording.
-    def read_audio(buffer, max_samples = 4096)
+    def read_audio(buffer, max_samples = 2048)
       samples = ps_api.ad_read(@ps_audio_device, buffer, max_samples)
       samples if samples >= 0
     end
@@ -60,8 +60,8 @@ module Pocketsphinx
     # we specify a delay which should fill half of the max buffer size
     #
     # @param [Fixnum] max_samples The maximum samples we tried to read from the audio device
-    def read_audio_delay(max_samples = 4096)
-      max_samples.to_f / (2 * sample_rate)
+    def read_audio_delay(max_samples = 2048)
+      max_samples.to_f / sample_rate
     end
 
     def close_device

--- a/lib/pocketsphinx/speech_recognizer.rb
+++ b/lib/pocketsphinx/speech_recognizer.rb
@@ -43,7 +43,7 @@ module Pocketsphinx
     # Recognize speech and yield hypotheses in infinite loop
     #
     # @param [Fixnum] max_samples Number of samples to process at a time
-    def recognize(max_samples = 4096, &b)
+    def recognize(max_samples = 2048, &b)
       unless ALGORITHMS.include?(algorithm)
         raise NotImplementedError, "Unknown speech recognition algorithm: #{algorithm}"
       end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -65,7 +65,7 @@ describe Pocketsphinx::Configuration do
 
   describe '#setting_names' do
     it 'contains the names of all possible system settings' do
-      expect(subject.setting_names.count).to eq(112)
+      expect(subject.setting_names.count).to eq(113)
     end
   end
 
@@ -84,7 +84,7 @@ describe Pocketsphinx::Configuration do
     it 'gives details for all settings when no name is specified' do
       details = subject.details
 
-      expect(details.count).to eq(112)
+      expect(details.count).to eq(113)
       expect(details.first).to eq({
         name: "agc",
         type: :string,

--- a/spec/decoder_spec.rb
+++ b/spec/decoder_spec.rb
@@ -64,24 +64,24 @@ describe Pocketsphinx::Decoder do
 
   describe '#process_raw' do
     it 'calls libpocketsphinx' do
-      FFI::MemoryPointer.new(:int16, 4096) do |buffer|
+      FFI::MemoryPointer.new(:int16, 2048) do |buffer|
         expect(ps_api)
           .to receive(:ps_process_raw)
-          .with(subject.ps_decoder, buffer, 4096, 0, 0)
+          .with(subject.ps_decoder, buffer, 2048, 0, 0)
           .and_return(0)
 
-        subject.process_raw(buffer, 4096, false, false)
+        subject.process_raw(buffer, 2048, false, false)
       end
     end
 
     it 'raises an exception on error' do
-      FFI::MemoryPointer.new(:int16, 4096) do |buffer|
+      FFI::MemoryPointer.new(:int16, 2048) do |buffer|
         expect(ps_api)
           .to receive(:ps_process_raw)
-          .with(subject.ps_decoder, buffer, 4096, 0, 0)
+          .with(subject.ps_decoder, buffer, 2048, 0, 0)
           .and_return(-1)
 
-        expect { subject.process_raw(buffer, 4096, false, false) }
+        expect { subject.process_raw(buffer, 2048, false, false) }
           .to raise_exception "Decoder#process_raw failed with error code -1"
       end
     end

--- a/spec/integration/decoder_spec.rb
+++ b/spec/integration/decoder_spec.rb
@@ -41,8 +41,8 @@ describe Pocketsphinx::Decoder do
       subject.decode File.open('spec/assets/audio/goforward.raw', 'rb')
 
       expect(subject.words.map(&:word)).to eq(["<s>", "go", "forward", "ten", "meters", "</s>"])
-      expect(subject.words.map(&:start_frame)).to eq([51, 54, 66, 119, 155, 214])
-      expect(subject.words.map(&:end_frame)).to eq([53, 65, 118, 154, 213, 262])
+      expect(subject.words.map(&:start_frame)).to eq([0, 46, 64, 117, 153, 212])
+      expect(subject.words.map(&:end_frame)).to eq([45, 63, 116, 152, 211, 260])
     end
   end
 end

--- a/spec/integration/default_recognition_spec.rb
+++ b/spec/integration/default_recognition_spec.rb
@@ -14,7 +14,7 @@ describe 'speech recognition with default configuration' do
 
   describe '#recognize' do
     it 'should decode speech in raw audio' do
-      expect { |b| subject.recognize('spec/assets/audio/goforward.raw', 4096, &b) }.
+      expect { |b| subject.recognize('spec/assets/audio/goforward.raw', 2048, &b) }.
         to yield_with_args("go forward ten meters")
     end
   end

--- a/spec/integration/grammar_recognition_spec.rb
+++ b/spec/integration/grammar_recognition_spec.rb
@@ -18,7 +18,7 @@ describe 'speech recognition with a grammar' do
 
   describe '#recognize' do
     it 'should decode speech in raw audio' do
-      expect { |b| subject.recognize(4096, &b) }.to yield_with_args("go forward ten meters")
+      expect { |b| subject.recognize(2048, &b) }.to yield_with_args("go forward ten meters")
     end
   end
 end

--- a/spec/integration/keyword_recognition_spec.rb
+++ b/spec/integration/keyword_recognition_spec.rb
@@ -19,7 +19,7 @@ describe 'keyword spotting' do
 
   describe '#recognize' do
     it 'should decode speech in raw audio' do
-      expect { |b| subject.recognize(4096, &b) }.to yield_with_args('forward')
+      expect { |b| subject.recognize(2048, &b) }.to yield_with_args('forward')
     end
   end
 end

--- a/spec/microphone_spec.rb
+++ b/spec/microphone_spec.rb
@@ -72,16 +72,16 @@ describe Pocketsphinx::Microphone do
     it 'calls libsphinxad' do
       expect(ps_api)
         .to receive(:ad_read)
-        .with(subject.ps_audio_device, :buffer, 4096)
+        .with(subject.ps_audio_device, :buffer, 2048)
         .and_return(0)
 
-      subject.read_audio(:buffer, 4096)
+      subject.read_audio(:buffer, 2048)
     end
   end
 
   describe '#read_audio_delay' do
-    it 'should be 0.128 seconds for a max_samples of 4096 and sample rate of 16kHz' do
-      expect(subject.read_audio_delay(4096)).to eq(0.128)
+    it 'should be 0.128 seconds for a max_samples of 2048 and sample rate of 16kHz' do
+      expect(subject.read_audio_delay(2048)).to eq(0.128)
     end
   end
 


### PR DESCRIPTION
Unfortunately pocketsphinx can not handle 4096 samples at once, it might skip the short silence and the recognizer timings will be broken. It the future we might fix pocketsphinx API in regards to silence but for now we have to reduce buffer size.
