### PR TITLE
Convert posterior probability using logmath_exp.

### DIFF
--- a/lib/pocketsphinx/api/pocketsphinx.rb
+++ b/lib/pocketsphinx/api/pocketsphinx.rb
@@ -6,6 +6,7 @@ module Pocketsphinx
 
       typedef :pointer, :decoder
       typedef :pointer, :configuration
+      typedef :pointer, :logmath
 
       # Allows expect(API::Pocketsphinx).to receive(:ps_init) in JRuby specs
       def self.ps_init(*args)
@@ -23,6 +24,9 @@ module Pocketsphinx
       attach_function :ps_get_in_speech, [:decoder], :uint8
       attach_function :ps_get_hyp, [:decoder, :pointer], :string
       attach_function :ps_get_prob, [:decoder], :int32
+      attach_function :ps_get_logmath, [:decoder], :logmath
+      attach_function :logmath_get_base, [:logmath], FFI::NativeType::FLOAT64
+      attach_function :logmath_exp, [:logmath, :int], FFI::NativeType::FLOAT64
       attach_function :ps_set_jsgf_string, [:decoder, :string, :string], :int
       attach_function :ps_unset_search, [:decoder, :string], :int
       attach_function :ps_get_search, [:decoder], :string

--- a/lib/pocketsphinx/decoder.rb
+++ b/lib/pocketsphinx/decoder.rb
@@ -117,9 +117,10 @@ module Pocketsphinx
     # @return [Hypothesis] Hypothesis (behaves like a string)
     def hypothesis
       mp_path_score = FFI::MemoryPointer.new(:int32, 1)
+      logmath = ps_api.ps_get_logmath(ps_decoder)
 
       hypothesis = ps_api.ps_get_hyp(ps_decoder, mp_path_score)
-      posterior_prob = ps_api.ps_get_prob(ps_decoder)
+      posterior_prob = ps_api.logmath_exp(logmath, mp_path_score.get_int32(0))
 
       hypothesis.nil? ? nil : Hypothesis.new(
         hypothesis,


### PR DESCRIPTION
This is based on the comment by @chinshr on
https://github.com/watsonbox/pocketsphinx-ruby/issues/18#issuecomment-101506602

This conversion makes `posterior_prob` a usable confidence value between
0 and 1.