### PR TITLE
SphinxBase API change breaks 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+**v0.3.1 - 16/07/17**
+
+* SphinxBase API change [removes `err_set_debug_level`](https://github.com/cmusphinx/sphinxbase/commit/69c473ca648b8e2f8e453f27a405107a245bbcdd).
+
+
 **v0.3.0 - 17/04/15**
 
 * Add Words support to Decoder

--- a/lib/pocketsphinx/api/sphinxbase.rb
+++ b/lib/pocketsphinx/api/sphinxbase.rb
@@ -19,7 +19,6 @@ module Pocketsphinx
       attach_function :cmd_ln_set_int_r, [:pointer, :string, :int], :void
       attach_function :cmd_ln_str_r, [:pointer, :string], :string
       attach_function :cmd_ln_set_str_r, [:pointer, :string, :string], :void
-      attach_function :err_set_debug_level, [:int], :int
       attach_function :err_set_logfile, [:string], :int
       attach_function :err_set_logfp, [:pointer], :void
     end

--- a/lib/pocketsphinx/version.rb
+++ b/lib/pocketsphinx/version.rb
@@ -1,3 +1,3 @@
 module Pocketsphinx
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end


### PR DESCRIPTION
Hi there!

It seems that [a small API removal](https://github.com/cmusphinx/sphinxbase/commit/69c473ca648b8e2f8e453f27a405107a245bbcdd) over on the side of `sphinxbase` causes FFI to choke on this while loading the library. I edited the changelog and looked for other references for that binding, but it seems that there weren't any (or maybe I missed one?). 

At any rate, this should fix it 👍 !